### PR TITLE
Fixed issue where there is no default image.

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

I changed a line of code in the ItemPreview.js file to show an image placeholder by default if there is no value for the image.
![image](https://user-images.githubusercontent.com/71044539/216776961-2f799d72-6e03-4f2c-9f6a-5cdbb30ee00f.png)
